### PR TITLE
fix: hmr, file resolution warnings

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -37,7 +37,7 @@
     "build-esm": "cross-env ESM=1 babel src --ignore '**/__tests__/**,**/__mocks__/**,*.spec.*' --out-dir esm/",
     "build-bundles": "yarn build-bundles-clean && yarn build-bundles-dev && yarn build-bundles-min",
     "build-bundles-dev": "cross-env NODE_ENV=development CDN=1 yarn webpack -d --bail",
-    "build-bundles-min": "cross-env NODE_ENV=production CDN=1 yarn webpack -p --bail",
+    "build-bundles-min": "cross-env ANALYZE=1 NODE_ENV=production CDN=1 yarn webpack -p --bail",
     "build-bundles-clean": "rimraf 'graphiql.*{js,css}' *.html",
     "build-flow": "node ../../resources/buildFlow.js",
     "check": "flow check",

--- a/packages/graphiql/test/dev-server.js
+++ b/packages/graphiql/test/dev-server.js
@@ -16,14 +16,7 @@ const webpackConfig = require('../resources/webpack.config');
 
 const compiler = Webpack(webpackConfig);
 
-const devServerOptions = {
-  ...webpackConfig.devServer,
-  ...{
-    stats: {
-      colors: true,
-    },
-  },
-};
+const devServerOptions = webpackConfig.devServer
 
 const app = new WebpackDevServer(compiler, devServerOptions);
 
@@ -32,11 +25,6 @@ app.use('/graphql', graphqlHTTP({ schema }));
 app.listen(8080, '127.0.0.1', () => {
   console.log('Starting server on http://localhost:8080');
 });
-
-app.use(
-  '../graphiql.css',
-  express.static(path.join(__dirname, '../graphiql.css')),
-);
 
 app.use('/images', express.static(path.join(__dirname, 'images')));
 

--- a/packages/graphql-language-service-utils/src/file.ts
+++ b/packages/graphql-language-service-utils/src/file.ts
@@ -32,8 +32,8 @@ function handleExtensionErr(extension: string | null) {
 const resolveJs = (path: string) => require.resolve(path + '.js');
 const resolveJSON = (path: string) => require.resolve(path + '.json');
 
-const importJs = (path: string) => import(path + '.js');
-const importJSON = (path: string) => import(path + '.json');
+const importJs = (path: string) => require(path + '.js');
+const importJSON = (path: string) => require(path + '.json');
 
 export function resolveFile(filePath: string) {
   const extension = getFileExtension(filePath);


### PR DESCRIPTION
- hmr bug was loading minified version in dev server index.html
- file resolution warnings from .d.ts and map files.
  - we will want those for ts-loader soon!
- analyzer path for deploy previews at /analyzer
- file.ts switched to use require() for now
  - using import() got rid of extension based dynamic resoltion
  - might be a config issue on our end or a webpack bug

Reviewed-By: @ryan-m-walker