### PR TITLE
chore(release): publish

### DIFF
--- a/examples/graphiql-cdn/CHANGELOG.md
+++ b/examples/graphiql-cdn/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 0.0.8-alpha.0 (2020-01-18)
-
 **Note:** Version bump only for package example-graphiql-cdn
+
+## 0.0.8-alpha.1 (2020-01-18)
 
 ## [0.0.7](https://github.com/graphql/graphiql/compare/graphiql-example-cdn@0.0.6...graphiql-example-cdn@0.0.7) (2019-12-03)
 

--- a/examples/graphiql-cdn/package.json
+++ b/examples/graphiql-cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-graphiql-cdn",
-  "version": "0.0.8-alpha.0",
+  "version": "0.0.8-alpha.1",
   "private": true,
   "license": "MIT",
   "description": "An example using GraphiQL",

--- a/examples/graphiql-webpack/CHANGELOG.md
+++ b/examples/graphiql-webpack/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 1.0.0-alpha.0 (2020-01-18)
+# 1.0.0-alpha.1 (2020-01-18)
 
 ### Features
 

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-graphiql-webpack",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "private": true,
   "license": "MIT",
   "description": "A GraphiQL example with webpack and typescript",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     }
   },
   "scripts": {
-    "build": "yarn run build-clean && yarn build-ts && yarn build-js",
+    "build": "yarn run build-clean && yarn build-ts-cjs && yarn build-js",
     "build-js": "lerna run build --scope codemirror-graphql",
-    "build-ts": "yarn run tsc",
+    "build-ts-cjs": "yarn run tsc resources/tsconfig.build.cjs.json",
+    "build-ts-esm": "yarn run tsc resources/tsconfig.build.esm.json",
     "build-clean": "yarn run tsc --clean && rimraf '{packages,examples}/**/{dist,esm,bundle,cdn,webpack,storybook}' && lerna run build-clean --parallel",
     "build-validate": "lerna run build-validate",
     "build-demo": "lerna run build-demo",
     "build-docs": "rimraf 'packages/graphiql/lsp' && typedoc 'packages'",
-    "build-bundles": "lerna run build-bundles",
+    "build-bundles": "yarn build-ts-esm && lerna run build-bundles",
     "tsc": "tsc --build",
     "test": "yarn build && yarn run testonly",
     "ci": "yarn run lint && yarn run check && yarn run build && yarn run testonly && yarn build-bundles && yarn run e2e && yarn build-validate",

--- a/packages/codemirror-graphql/CHANGELOG.md
+++ b/packages/codemirror-graphql/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.12.0-alpha.0](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.6...codemirror-graphql@0.12.0-alpha.0) (2020-01-18)
+# [0.12.0-alpha.1](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.6...codemirror-graphql@0.12.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror-graphql",
-  "version": "0.12.0-alpha.0",
+  "version": "0.12.0-alpha.1",
   "description": "GraphQL mode and helpers for CodeMirror.",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",
@@ -52,8 +52,8 @@
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "graphql-language-service-interface": "^2.4.0-alpha.0",
-    "graphql-language-service-parser": "^1.5.3-alpha.0"
+    "graphql-language-service-interface": "^2.4.0-alpha.1",
+    "graphql-language-service-parser": "^1.5.3-alpha.1"
   },
   "devDependencies": {
     "chai": "4.1.1",

--- a/packages/graphiql/CHANGELOG.md
+++ b/packages/graphiql/CHANGELOG.md
@@ -3,24 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.0.0-alpha.0](https://github.com/graphql/graphiql/compare/graphiql@0.17.5...graphiql@1.0.0-alpha.0) (2020-01-18)
+# [1.0.0-alpha.1](https://github.com/graphql/graphiql/compare/graphiql@0.17.5...graphiql@1.0.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 
 - hmr, file resolution warnings ([69bf701](https://github.com/graphql/graphiql/commit/69bf701))
-- linting issues, trailingCommas: all ([#1099](https://github.com/graphql/graphiql/issues/1099)) ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
 - prefer displayName over type equality for children overrides ([e4cec0a](https://github.com/graphql/graphiql/commit/e4cec0a))
-- remove use of find dom node ([0b12323](https://github.com/graphql/graphiql/commit/0b12323))
-- screenshot/gif urls ([e3ea2fc](https://github.com/graphql/graphiql/commit/e3ea2fc))
+  - remove use of `findDOMNode` ([0b12323](https://github.com/graphql/graphiql/commit/0b12323)) by [@ryan-m-walker](https://github.com/ryan-m-walker)
 
 ### Features
 
-- convert LSP Server to Typescript, remove watchman ([#1138](https://github.com/graphql/graphiql/issues/1138)) ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
-- **graphiql-theming:** Toolbar component ([#1203](https://github.com/graphql/graphiql/issues/1203)) by [@walaura](https://github.com/walaura) ([adb73f5](https://github.com/graphql/graphiql/commit/adb73f5))
-- [new-ui] Tabs & Tabbars ([#1198](https://github.com/graphql/graphiql/issues/1198)) ([033f971](https://github.com/graphql/graphiql/commit/033f971))
 - deprecate support for 15, support react 16 features ([#1107](https://github.com/graphql/graphiql/issues/1107)) ([bc4b6fc](https://github.com/graphql/graphiql/commit/bc4b6fc))
+- **graphiql-theming:** Toolbar component ([#1203](https://github.com/graphql/graphiql/issues/1203)) by [@walaura](https://github.com/walaura) ([adb73f5](https://github.com/graphql/graphiql/commit/adb73f5))
+- [new-ui] Tabs & Tabbars ([#1198](https://github.com/graphql/graphiql/issues/1198)) ([033f971](https://github.com/graphql/graphiql/commit/033f971)) by [@walaura](https://github.com/walaura)
 - replace use of enzyme with react-testing-library ([#1144](https://github.com/graphql/graphiql/issues/1144)) by [@ryan-m-walker](https://github.com/ryan-m-walker) ([de73d6c](https://github.com/graphql/graphiql/commit/de73d6c))
-- storybook+theme-ui for the new design ([#1145](https://github.com/graphql/graphiql/issues/1145)) ([7f97c0c](https://github.com/graphql/graphiql/commit/7f97c0c))
+- storybook+theme-ui for the new design ([#1145](https://github.com/graphql/graphiql/issues/1145)) ([7f97c0c](https://github.com/graphql/graphiql/commit/7f97c0c)) by [@walaura](https://github.com/walaura)
 
 ### BREAKING CHANGES
 

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "An graphical interactive in-browser GraphQL IDE.",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",
@@ -46,7 +46,7 @@
     "@emotion/core": "^10.0.22",
     "@mdx-js/react": "^1.5.2",
     "codemirror": "^5.47.0",
-    "codemirror-graphql": "^0.12.0-alpha.0",
+    "codemirror-graphql": "^0.12.0-alpha.1",
     "copy-to-clipboard": "^3.2.0",
     "entities": "^2.0.0",
     "markdown-it": "^10.0.0",

--- a/packages/graphiql/src/cdn.js
+++ b/packages/graphiql/src/cdn.js
@@ -18,5 +18,5 @@ import './css/show-hint.css';
 import './css/doc-explorer.css';
 import './css/history.css';
 
-import { GraphiQL } from './components/GraphiQL';
 export default GraphiQL;
+import { GraphiQL } from './components/GraphiQL';

--- a/packages/graphiql/src/components/DocExplorer.js
+++ b/packages/graphiql/src/components/DocExplorer.js
@@ -55,7 +55,7 @@ export class DocExplorer extends React.Component {
   }
 
   render() {
-    const schema = this.props.schema;
+    const { schema } = this.props;
     const navStack = this.state.navStack;
     const navItem = navStack[navStack.length - 1];
 

--- a/packages/graphiql/src/components/__tests__/DocExplorer.spec.js
+++ b/packages/graphiql/src/components/__tests__/DocExplorer.spec.js
@@ -9,6 +9,8 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { DocExplorer } from '../DocExplorer';
 
+import { ExampleSchema } from './ExampleSchema';
+
 describe('DocExplorer', () => {
   it('renders spinner when no schema prop is present', () => {
     const { container } = render(<DocExplorer />);
@@ -20,5 +22,10 @@ describe('DocExplorer', () => {
     const error = container.querySelectorAll('.error-container');
     expect(error).toHaveLength(1);
     expect(error[0]).toHaveTextContent('No Schema Available');
+  });
+  it('renders with schema', () => {
+    const { container } = render(<DocExplorer schema={ExampleSchema} />);
+    const error = container.querySelectorAll('.error-container');
+    expect(error).toHaveLength(0);
   });
 });

--- a/packages/graphiql/src/index.js
+++ b/packages/graphiql/src/index.js
@@ -7,4 +7,5 @@
 import 'regenerator-runtime/runtime';
 
 import { GraphiQL } from './components/GraphiQL';
+
 export default GraphiQL;

--- a/packages/graphql-language-service-interface/CHANGELOG.md
+++ b/packages/graphql-language-service-interface/CHANGELOG.md
@@ -3,11 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.4.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-interface@2.3.3...graphql-language-service-interface@2.4.0-alpha.0) (2020-01-18)
-
-### Bug Fixes
-
-- linting issues, trailingCommas: all ([#1099](https://github.com/graphql/graphiql/issues/1099)) ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
+# [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-interface@2.3.3...graphql-language-service-interface@2.4.0-alpha.1) (2020-01-18)
 
 ### Features
 

--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-interface",
-  "version": "2.4.0-alpha.0",
+  "version": "2.4.0-alpha.1",
   "description": "Interface to the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -22,7 +22,7 @@
   ],
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "typings": "esm/index.d.ts",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "test": "node ../../resources/runTests.js",
     "build": "yarn run build-ts && yarn run build-flow",
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-parser": "^1.5.3-alpha.0",
-    "graphql-language-service-types": "^1.6.0-alpha.0",
-    "graphql-language-service-utils": "^2.4.0-alpha.0"
+    "graphql-language-service-parser": "^1.5.3-alpha.1",
+    "graphql-language-service-types": "^1.6.0-alpha.1",
+    "graphql-language-service-utils": "^2.4.0-alpha.1"
   }
 }

--- a/packages/graphql-language-service-parser/CHANGELOG.md
+++ b/packages/graphql-language-service-parser/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.5.3-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-parser@1.5.2...graphql-language-service-parser@1.5.3-alpha.0) (2020-01-18)
+## [1.5.3-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-parser@1.5.2...graphql-language-service-parser@1.5.3-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 

--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-parser",
-  "version": "1.5.3-alpha.0",
+  "version": "1.5.3-alpha.1",
   "description": "An online parser for GraphQL for use in syntax-highlighters and code intelligence tools",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -22,7 +22,7 @@
   ],
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "typings": "esm/index.d.ts",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "build": "yarn run build-ts && yarn run build-flow",
     "build-ts": "tsc",
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-types": "^1.6.0-alpha.0"
+    "graphql-language-service-types": "^1.6.0-alpha.1"
   }
 }

--- a/packages/graphql-language-service-server/CHANGELOG.md
+++ b/packages/graphql-language-service-server/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.4.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.3...graphql-language-service-server@2.4.0-alpha.0) (2020-01-18)
+# [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.3...graphql-language-service-server@2.4.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-server",
-  "version": "2.4.0-alpha.0",
+  "version": "2.4.0-alpha.1",
   "description": "Server process backing the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -22,7 +22,7 @@
   ],
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "typings": "esm/index.d.ts",
+  "typings": "dist/index.d.ts",
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
@@ -30,9 +30,9 @@
     "@babel/parser": "^7.4.5",
     "glob": "^7.1.2",
     "graphql-config": "2.2.1",
-    "graphql-language-service-interface": "^2.4.0-alpha.0",
-    "graphql-language-service-types": "^1.6.0-alpha.0",
-    "graphql-language-service-utils": "^2.4.0-alpha.0",
+    "graphql-language-service-interface": "^2.4.0-alpha.1",
+    "graphql-language-service-types": "^1.6.0-alpha.1",
+    "graphql-language-service-utils": "^2.4.0-alpha.1",
     "nullthrows": "^1.0.0",
     "vscode-jsonrpc": "^4.0.0",
     "vscode-languageserver": "^5.2.1"

--- a/packages/graphql-language-service-types/CHANGELOG.md
+++ b/packages/graphql-language-service-types/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.6.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-types@1.5.2...graphql-language-service-types@1.6.0-alpha.0) (2020-01-18)
+# [1.6.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-types@1.5.2...graphql-language-service-types@1.6.0-alpha.1) (2020-01-18)
 
 ### Features
 

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-types",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "Types for building GraphQL language services for IDEs",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",

--- a/packages/graphql-language-service-utils/CHANGELOG.md
+++ b/packages/graphql-language-service-utils/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.4.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-utils@2.3.3...graphql-language-service-utils@2.4.0-alpha.0) (2020-01-18)
+# [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-utils@2.3.3...graphql-language-service-utils@2.4.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 

--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-utils",
-  "version": "2.4.0-alpha.0",
+  "version": "2.4.0-alpha.1",
   "description": "Utilities to support the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-types": "^1.6.0-alpha.0"
+    "graphql-language-service-types": "^1.6.0-alpha.1"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23"

--- a/packages/graphql-language-service/CHANGELOG.md
+++ b/packages/graphql-language-service/CHANGELOG.md
@@ -3,11 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.4.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service@2.3.4...graphql-language-service@2.4.0-alpha.0) (2020-01-18)
-
-### Bug Fixes
-
-- linting issues, trailingCommas: all ([#1099](https://github.com/graphql/graphiql/issues/1099)) ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
+# [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service@2.3.4...graphql-language-service@2.4.0-alpha.1) (2020-01-18)
 
 ### Features
 

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service",
-  "version": "2.4.0-alpha.0",
+  "version": "2.4.0-alpha.1",
   "description": "An interface for building GraphQL language services for IDEs",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",
@@ -29,9 +29,9 @@
   "dependencies": {
     "@babel/polyfill": "7.8.3",
     "graphql-config": "2.2.1",
-    "graphql-language-service-interface": "^2.4.0-alpha.0",
-    "graphql-language-service-server": "^2.4.0-alpha.0",
-    "graphql-language-service-utils": "^2.4.0-alpha.0",
+    "graphql-language-service-interface": "^2.4.0-alpha.1",
+    "graphql-language-service-server": "^2.4.0-alpha.1",
+    "graphql-language-service-utils": "^2.4.0-alpha.1",
     "yargs": "^3.32.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
 - example-graphiql-cdn@0.0.8-alpha.0
 - example-graphiql-webpack@1.0.0-alpha.0
 - codemirror-graphql@0.12.0-alpha.0
 - graphiql@1.0.0-alpha.0
 - graphql-language-service-interface@2.4.0-alpha.0
 - graphql-language-service-parser@1.5.3-alpha.0
 - graphql-language-service-server@2.4.0-alpha.0
 - graphql-language-service-types@1.6.0-alpha.0
 - graphql-language-service-utils@2.4.0-alpha.0
 - graphql-language-service@2.4.0-alpha.0