### PR TITLE
chore: improve CI scripts, fix crosswise test resolution, cleanup (#1…

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -31,9 +31,11 @@
 packages/graphiql/webpack
 packages/graphiql/storybook
 packages/graphiql/lsp
+packages/graphiql/*.html
 **/renderExample.js
 **/*.min.js
 **/coverage/
+.nyc_output/
 
 
 # codemirror's build artefacts are exported from the package root

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,8 +56,8 @@ to run tests for GraphiQL:
 2. `yarn build` - cleans first, then builds everything but webpack bundles - `tsc --build`, `babel` etc
 3. `yarn build-bundles` - builds webpack bundles that are used for releases
 4. `yarn build-demo` - builds demo projects for netlify; we run this on CI to make sure webpack can consume our project in a standalone project.
-5. `yarn test` - runs all of the above alongside linting and checks, jest mocha Cypress, and runs all builds
+5. `yarn test` - runs `jest`. so `yarn t --watch`
 6. `yarn format` - autoformats with eslint --fix and prettier
 7. `yarn lint` - checks for linting issues
 8. `yarn e2e` - runs cypress headlessly against the minified bundle and a local schema server, like in CI.
-9. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn jest --watch` or `yarn jest DocExplorer` for example :D
+9. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn test --watch` or `yarn jtest DocExplorer` for example :D

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,10 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       'identity-obj-proxy',
     '\\.(css|less)$': 'identity-obj-proxy',
+    '^graphql-language-([^/]+)': '<rootDir>/packages/graphql-language-$1/src',
+    '^codemirror-graphql\\/([^]+)':
+      '<rootDir>/packages/codemirror-graphql/src/$1',
+    '^example-([^/]+)': '<rootDir>/examples/$1/src',
   },
   transform: {
     '^.+\\.jsx?$': require.resolve('./resources/jestBabelTransform'),

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "yarn && yarn build && yarn build-bundles && yarn build-demo && yarn build-docs"
+  command = "yarn build-bundles && yarn build-demo && yarn build-docs"
   publish = "packages/graphiql"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{md,html,json,toml}": [
+    "*.{md,html,json}": [
       "prettier --write"
     ]
   },
@@ -21,18 +21,23 @@
     }
   },
   "scripts": {
-    "build": "yarn run build-clean && yarn build-ts-cjs && yarn build-js",
-    "build-js": "lerna run build --scope codemirror-graphql",
-    "build-ts-cjs": "yarn run tsc resources/tsconfig.build.cjs.json",
-    "build-ts-esm": "yarn run tsc resources/tsconfig.build.esm.json",
-    "build-clean": "yarn run tsc --clean && rimraf '{packages,examples}/**/{dist,esm,bundle,cdn,webpack,storybook}' && lerna run build-clean --parallel",
+    "build": "yarn run build-clean && yarn build-ts-cjs && yarn build-babel",
+    "build-babel": "lerna run build --scope codemirror-graphql",
+    "build-ts": "yarn run tsc --clean && yarn run tsc",
+    "build-ts-cjs": "yarn run tsc resources/tsconfig.build.cjs.json --clean && yarn run tsc resources/tsconfig.build.cjs.json",
+    "build-ts-esm": "yarn run tsc resources/tsconfig.build.esm.json --clean && yarn run tsc resources/tsconfig.build.esm.json",
+    "build-clean": "yarn run tsc --clean && rimraf '{packages,examples}/**/{dist,esm}' && lerna run build-clean",
     "build-validate": "lerna run build-validate",
     "build-demo": "lerna run build-demo",
     "build-docs": "rimraf 'packages/graphiql/lsp' && typedoc 'packages'",
-    "build-bundles": "yarn build-ts-esm && lerna run build-bundles",
+    "build-bundles": "yarn prebuild-bundles && yarn workspace graphiql run build-bundles",
+    "prebuild-bundles": "yarn build-ts-esm && yarn build-bundles-clean",
+    "build-bundles-clean": "rimraf '{packages,examples}/**/{bundle,cdn,webpack}' && lerna run build-bundles-clean",
     "tsc": "tsc --build",
-    "test": "yarn build && yarn run testonly",
-    "ci": "yarn run lint && yarn run check && yarn run build && yarn run testonly && yarn build-bundles && yarn run e2e && yarn build-validate",
+    "test": "jest",
+    "test-mocha": "yarn workspace codemirror-graphql run test",
+    "test-all": "yarn test && yarn test-mocha",
+    "ci": "yarn lint && yarn run check && yarn test && yarn build && yarn test-mocha && yarn build-bundles && yarn e2e && yarn build-validate",
     "testonly": "jest && yarn workspace codemirror-graphql run test",
     "e2e": "yarn workspace graphiql e2e",
     "cypress-open": "yarn workspace graphiql cypress-open",
@@ -45,7 +50,8 @@
     "pretty": "node resources/pretty.js",
     "pretty-check": "node resources/pretty.js --check",
     "format": "yarn eslint --fix && yarn pretty",
-    "lerna-publish": "lerna publish"
+    "lerna-publish": "lerna publish",
+    "prepublish": "yarn lint && yarn build && yarn build-bundles && yarn test-all && yarn e2e"
   },
   "devDependencies": {
     "@babel/cli": "7.7.7",

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -37,8 +37,6 @@
     "mocha": "--full-trace --require resources/mochaBootload **/*-test.js"
   },
   "scripts": {
-    "lint": "eslint src",
-    "check": "flow check",
     "build": "yarn build-clean && yarn build-js && yarn build-esm && yarn build-flow .",
     "build-js": "babel src --root-mode upward --ignore **/__tests__/**,**/__mocks__/** --out-dir .",
     "build-esm": "cross-env ESM=true babel src --root-mode upward  --ignore **/__tests__/**,**/__mocks__/** --out-dir esm && node ../../resources/renameFileExtensions.js './esm/{**,!**/__tests__/}/*.js' . .esm.js",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -39,7 +39,6 @@
     "cypress-open": "yarn e2e-server 'cypress open'",
     "e2e": "yarn e2e-server 'cypress run'",
     "e2e-server": "start-server-and-test 'cross-env PORT=8080 node test/e2e-server' 'http-get://localhost:8080/graphql?query={test { id }}'",
-    "test": "node ../../resources/runTests",
     "storybook": "start-storybook"
   },
   "dependencies": {

--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -23,12 +23,6 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
-  "scripts": {
-    "test": "node ../../resources/runTests.js",
-    "build": "yarn run build-ts && yarn run build-flow",
-    "build-ts": "tsc",
-    "build-flow": "node ../../resources/buildFlow.js"
-  },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },

--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -23,11 +23,6 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
-  "scripts": {
-    "build": "yarn run build-ts && yarn run build-flow",
-    "build-ts": "tsc",
-    "build-flow": "node ../../resources/buildFlow.js"
-  },
   "peerDependencies": {
     "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },

--- a/packages/graphql-language-service-server/tsconfig.esm.json
+++ b/packages/graphql-language-service-server/tsconfig.esm.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../resources/tsconfig.base.esm.json",
   "compilerOptions": {
+    "target": "ES2017",
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./esm"
   },

--- a/packages/graphql-language-service-server/tsconfig.json
+++ b/packages/graphql-language-service-server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../resources/tsconfig.base.cjs.json",
   "compilerOptions": {
+    "target": "ES2017",
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -23,11 +23,6 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
-  "scripts": {
-    "build": "yarn run build-ts && yarn run build-flow",
-    "build-ts": "tsc",
-    "build-flow": "node ../../resources/buildFlow.js"
-  },
   "peerDependencies": {
     "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },

--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -27,12 +27,6 @@
     "node": ">= 9.7.3"
   },
   "engineStrict": true,
-  "scripts": {
-    "test": "node ../../resources/runTests.js",
-    "build": "yarn run build-ts && yarn run build-flow",
-    "build-ts": "tsc",
-    "build-flow": "node ../../resources/buildFlow.js"
-  },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8645,12 +8645,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 "graphiql@file:packages/graphiql":
-  version "0.17.5"
+  version "1.0.0-alpha.1"
   dependencies:
     "@emotion/core" "^10.0.22"
     "@mdx-js/react" "^1.5.2"
     codemirror "^5.47.0"
-    codemirror-graphql "^0.11.6"
+    codemirror-graphql "^0.12.0-alpha.1"
     copy-to-clipboard "^3.2.0"
     entities "^2.0.0"
     markdown-it "^10.0.0"


### PR DESCRIPTION
…245)

* chore: improve CI time, fix crosswise test resolution, cleanup

- fix jest issue w/ moduleNameMapper, so tests don't need a build to run
- reconfigured build tooling for more streamlined ci. fails more quickly.
- test = jest now
- remove most scripts from subpackages, almost everything should be done from root now
- use browserslist for esm exports